### PR TITLE
Add other (optional) parts of a human name

### DIFF
--- a/src/main/scala/de/dnpm/dip/model/HumanName.scala
+++ b/src/main/scala/de/dnpm/dip/model/HumanName.scala
@@ -5,7 +5,10 @@ package de.dnpm.dip.model
 final case class HumanName
 (
   givenName: String,
+  middleName: Option[String],
   familyName: String,
-  title: Option[String]
+  title: Option[String],
+  prefix: Option[String],
+  postfix: Option[String],
 )
 


### PR DESCRIPTION
Explanation: 

* Some names contain a middle name - this is useful if the middle name should not be included within 'givenName'
* A Prefix can be used for optional parts in front of other parts of the name
* A Postfix can be used for optional parts at the end of the full name